### PR TITLE
Streamlined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /data/output.txt
 /.vscode
 /data/knime_*
+eclipse-formatter.xml

--- a/src/com/jonassigel/AllowedType.java
+++ b/src/com/jonassigel/AllowedType.java
@@ -2,12 +2,12 @@ package com.jonassigel;
 
 import java.util.function.Function;
 
-public enum AllowedTypes {
+public enum AllowedType {
     INT(Integer::valueOf), DOUBLE(Double::valueOf), STRING(Object::toString);
 
     public final Function<String, ? super Object> stringCaster;
 
-    AllowedTypes(Function<String, ? super Object> stringCaster) {
+    AllowedType(Function<String, ? super Object> stringCaster) {
         this.stringCaster = stringCaster;
     }
 }

--- a/src/com/jonassigel/AllowedTypes.java
+++ b/src/com/jonassigel/AllowedTypes.java
@@ -1,0 +1,13 @@
+package com.jonassigel;
+
+import java.util.function.Function;
+
+public enum AllowedTypes {
+    INT(Integer::valueOf), DOUBLE(Double::valueOf), STRING(Object::toString);
+
+    public final Function<String, ? super Object> stringCaster;
+
+    AllowedTypes(Function<String, ? super Object> stringCaster) {
+        this.stringCaster = stringCaster;
+    }
+}

--- a/src/com/jonassigel/Main.java
+++ b/src/com/jonassigel/Main.java
@@ -51,13 +51,14 @@ public class Main {
 		// Extract and map necessary information
 		String typeString = argPairs.get("--inputtype").toUpperCase();
 
-		AllowedTypes type;
+		AllowedType type;
 		try {
-			type = Enum.valueOf(AllowedTypes.class, typeString);
+			type = Enum.valueOf(AllowedType.class, typeString);
 		} catch (IllegalArgumentException e) {
 			System.err.println("The supplied type " + typeString + " is not supported. Fallback is String.");
-			type = AllowedTypes.STRING;
+			type = AllowedType.STRING;
 		}
+
 		String[] ops = argPairs.get("--operations").split(",");
 		List<Transformer> transformers = Transform.generateTransformersFrom(ops);
 
@@ -86,7 +87,7 @@ public class Main {
 			// very fast.
 			// Test file: 35GB text, memory usage never over 8gb, completed successfully
 			// with parallel usage. Other method would have required loading all to memory,
-			// which is infeasible with just 16gb +8 swap ram
+			// which is not possible with just 16gb +8 swap ram
 			Stream<String> elements = sc.tokens().parallel();
 			Transform.transformInput(type, target, transformers, elements);
 		} catch (IOException e) {

--- a/src/com/jonassigel/Main.java
+++ b/src/com/jonassigel/Main.java
@@ -29,8 +29,9 @@ public class Main {
 	 * Takes data from file, transforms it with a series of operations and writes
 	 * the data out to some specified location
 	 * 
-	 * @param args The arguments as per the exercise PDF
-	 * @throws IOException 
+	 * @param args
+	 *            The arguments as per the exercise PDF
+	 * @throws IOException
 	 */
 	public static void main(String[] args) {
 		// add your code here
@@ -43,8 +44,20 @@ public class Main {
 		Set<String> arguments = Arguments.getPresentArguments(args, flags);
 		Map<String, String> argPairs = Arguments.getPariedArguments(args, flags);
 
+		if (arguments.isEmpty()) {
+			System.err.println("No arguments have been supplied! Exiting!");
+			System.exit(1);
+		}
 		// Extract and map necessary information
-		String type = argPairs.get("--inputtype").toLowerCase();
+		String typeString = argPairs.get("--inputtype").toUpperCase();
+
+		AllowedTypes type;
+		try {
+			type = Enum.valueOf(AllowedTypes.class, typeString);
+		} catch (IllegalArgumentException e) {
+			System.err.println("The supplied type " + typeString + " is not supported. Fallback is String.");
+			type = AllowedTypes.STRING;
+		}
 		String[] ops = argPairs.get("--operations").split(",");
 		List<Transformer> transformers = Transform.generateTransformersFrom(ops);
 

--- a/src/com/jonassigel/Statistics.java
+++ b/src/com/jonassigel/Statistics.java
@@ -8,13 +8,13 @@ import java.util.concurrent.atomic.LongAccumulator;
  * Captures statistics about the lines being read from the input file.
  * Thread-safe accumulation.
  * 
- * @author KNIME GmbH
+ * @author KNIME GmbH, enhanced by Jonas Sigel
  */
 public class Statistics {
 
 	private final Set<String> linesRead = ConcurrentHashMap.newKeySet();
 
-	private LongAccumulator lineCounter = new LongAccumulator((x, y) -> x + y, 0);
+	private final LongAccumulator lineCounter = new LongAccumulator((x, y) -> x + y, 0);
 
 	private static Statistics instance = null;
 
@@ -23,7 +23,7 @@ public class Statistics {
 	 * be called when a new line has been read from the input file.
 	 * 
 	 * @param line
-	 *             A new line that has been read from the input file.
+	 *            A new line that has been read from the input file.
 	 */
 	public void updateStatisticsWithLine(final String line) {
 		lineCounter.accumulate(1);

--- a/src/com/jonassigel/Transform.java
+++ b/src/com/jonassigel/Transform.java
@@ -15,89 +15,21 @@ import com.jonassigel.Transformers.Transformer;
 public class Transform {
 
     /**
-     * Transforms a given input depending on its type through the list of
-     * transformers. Each type needs to have its own instance sendoff
-     * 
-     * @param input
-     *            The target
-     * @param transformers
-     *            The list of operations to perform in order
-     * @return The result of all applications
-     */
-    public static Object transform(Object input, List<Transformer> transformers) {
-        throw new IllegalArgumentException("The supplied type doesn't have a pipeline yet");
-    }
-
-    /**
-     * Transforms a given input depending on its type through the list of
-     * transformers. Each type needs to have its own instance sendoff
-     * 
-     * @param input
-     *            The target
-     * @param transformers
-     *            The list of operations to perform in order
-     * @return The result of all applications
-     */
-    public static Double transform(Double d, List<Transformer> transformers) {
-        for (Transformer t : transformers) {
-            d = t.applyOnDouble(d);
-        }
-        return d;
-    }
-
-    /**
-     * Transforms a given input depending on its type through the list of
-     * transformers. Each type needs to have its own instance sendoff
-     * 
-     * @param input
-     *            The target
-     * @param transformers
-     *            The list of operations to perform in order
-     * @return The result of all applications
-     */
-    public static String transform(String s, List<Transformer> transformers) {
-
-        for (Transformer t : transformers) {
-            s = t.applyOnString(s);
-        }
-        return s;
-    }
-
-    /**
-     * Transforms a given input depending on its type through the list of
-     * transformers. Each type needs to have its own instance sendoff
-     * 
-     * @param input
-     *            The target
-     * @param transformers
-     *            The list of operations to perform in order
-     * @return The result of all applications
-     */
-    public static Integer transform(Integer i, List<Transformer> transformers) {
-        for (Transformer t : transformers) {
-            i = t.applyOnInteger(i);
-        }
-        return i;
-    }
-
-    /**
      * Takes a stream of inputs, transforms it and streams it to the output
      * 
      * @param type
      *            What type the incoming data has
      * @param target
      *            where the data should go to
-     * @param transformers
+     * @param transforms
      *            the operations to perform
      * @param elements
      *            the incoming data
-     * @throws IOException
-     *             if
      */
-    public static void transformInput(AllowedTypes type, OutputStream target, List<Transformer> transformers,
+    public static void transformInput(AllowedType type, OutputStream target, List<Transformer> transforms,
             Stream<String> elements) {
         OutputStreamWriter consume = new OutputStreamWriter(target);
-        Function<Object, Object> compiled = Util.compose(transformers.stream().map(t -> t.toTypedFunction(type)));
+        Function<Object, Object> compiled = Util.compose(transforms.stream().map(t -> t.toTypedFunction(type)));
         elements = elements.peek(s -> Statistics.getInstance().updateStatisticsWithLine(s));
         elements.map(type.stringCaster).map(compiled).forEachOrdered(r -> tryConsume(r, consume));
         try {

--- a/src/com/jonassigel/Transform.java
+++ b/src/com/jonassigel/Transform.java
@@ -6,6 +6,7 @@ import java.io.OutputStreamWriter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -14,23 +15,13 @@ import com.jonassigel.Transformers.Transformer;
 public class Transform {
 
     /**
-     * Fetches the respective transformers for each entry token
-     * 
-     * @param tokens The tokens of the operations
-     * @return The transformers in order
-     */
-    public static List<Transformer> generateTransformersFrom(String... tokens) {
-        return Arrays.stream(tokens)
-                .filter(s -> Objects.nonNull(s) && !s.isBlank()).map(String::trim).map(Transformer::toTransformer)
-                .collect(Collectors.toList());
-    }
-
-    /**
      * Transforms a given input depending on its type through the list of
      * transformers. Each type needs to have its own instance sendoff
      * 
-     * @param input        The target
-     * @param transformers The list of operations to perform in order
+     * @param input
+     *            The target
+     * @param transformers
+     *            The list of operations to perform in order
      * @return The result of all applications
      */
     public static Object transform(Object input, List<Transformer> transformers) {
@@ -41,8 +32,10 @@ public class Transform {
      * Transforms a given input depending on its type through the list of
      * transformers. Each type needs to have its own instance sendoff
      * 
-     * @param input        The target
-     * @param transformers The list of operations to perform in order
+     * @param input
+     *            The target
+     * @param transformers
+     *            The list of operations to perform in order
      * @return The result of all applications
      */
     public static Double transform(Double d, List<Transformer> transformers) {
@@ -56,11 +49,14 @@ public class Transform {
      * Transforms a given input depending on its type through the list of
      * transformers. Each type needs to have its own instance sendoff
      * 
-     * @param input        The target
-     * @param transformers The list of operations to perform in order
+     * @param input
+     *            The target
+     * @param transformers
+     *            The list of operations to perform in order
      * @return The result of all applications
      */
     public static String transform(String s, List<Transformer> transformers) {
+
         for (Transformer t : transformers) {
             s = t.applyOnString(s);
         }
@@ -71,8 +67,10 @@ public class Transform {
      * Transforms a given input depending on its type through the list of
      * transformers. Each type needs to have its own instance sendoff
      * 
-     * @param input        The target
-     * @param transformers The list of operations to perform in order
+     * @param input
+     *            The target
+     * @param transformers
+     *            The list of operations to perform in order
      * @return The result of all applications
      */
     public static Integer transform(Integer i, List<Transformer> transformers) {
@@ -85,45 +83,53 @@ public class Transform {
     /**
      * Takes a stream of inputs, transforms it and streams it to the output
      * 
-     * @param type         What type the incoming data has
-     * @param target       where the data should go to
-     * @param transformers the operations to perform
-     * @param elements     the incoming data
-     * @throws IOException if
+     * @param type
+     *            What type the incoming data has
+     * @param target
+     *            where the data should go to
+     * @param transformers
+     *            the operations to perform
+     * @param elements
+     *            the incoming data
+     * @throws IOException
+     *             if
      */
-    static void transformInput(String type, OutputStream target, List<Transformer> transformers,
+    public static void transformInput(AllowedTypes type, OutputStream target, List<Transformer> transformers,
             Stream<String> elements) {
         OutputStreamWriter consume = new OutputStreamWriter(target);
-
+        Function<Object, Object> compiled = Util.compose(transformers.stream().map(t -> t.toTypedFunction(type)));
         elements = elements.peek(s -> Statistics.getInstance().updateStatisticsWithLine(s));
-        switch (type) {
-            case "int":
-                elements.map(Integer::valueOf).map(i -> Transform.transform(i, transformers))
-                        .forEachOrdered(r -> tryConsume(r, consume));
-                break;
-            case "double":
-                elements.map(Double::valueOf).map(i -> Transform.transform(i, transformers))
-                        .forEachOrdered(r -> tryConsume(r, consume));
-                break;
-            default: // Remain String
-                elements.map(i -> Transform.transform(i, transformers))
-                        .forEachOrdered(r -> tryConsume(r, consume));
-        }
+        elements.map(type.stringCaster).map(compiled).forEachOrdered(r -> tryConsume(r, consume));
         try {
-
             target.flush();
             consume.close();
-
         } catch (IOException e) {
             System.err.println("Could not cleanup outputs after all operations: " + e.getMessage());
         }
     }
 
     /**
+     * Fetches the respective transformers for each entry token
+     * 
+     * @param tokens
+     *            The tokens of the operations
+     * @return The transformers in order
+     */
+    public static List<Transformer> generateTransformersFrom(String... tokens) {
+        return Arrays.stream(tokens)
+                .filter(s -> Objects.nonNull(s) && !s.isBlank())
+                .map(String::trim)
+                .map(Transformer::toTransformer)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Attempts to append the transformed data into the output.
      * 
-     * @param toConsume the generated element
-     * @param output    the upstream
+     * @param toConsume
+     *            the generated element
+     * @param output
+     *            the upstream
      */
     public static void tryConsume(Object toConsume, OutputStreamWriter output) {
         Objects.requireNonNull(toConsume);
@@ -131,9 +137,9 @@ public class Transform {
 
         try {
             output.append(toConsume.toString() + "\n");
-
         } catch (IOException e) {
             System.err.println("A value could not be written to the desired output");
         }
     }
+
 }

--- a/src/com/jonassigel/Transformers/Transformer.java
+++ b/src/com/jonassigel/Transformers/Transformer.java
@@ -1,5 +1,9 @@
 package com.jonassigel.Transformers;
 
+import java.util.function.Function;
+
+import com.jonassigel.AllowedTypes;
+
 /**
  * Declares data types that can be transformed.
  * Operations that do not have a compatible implementation automatically throw
@@ -9,6 +13,10 @@ package com.jonassigel.Transformers;
  * method. (Sadly type erasure destroyed another concept)
  */
 public abstract class Transformer {
+
+    public Object apply(Object t) {
+        throw new IllegalArgumentException("Type not applicable for " + this.getClass().getSimpleName());
+    }
 
     public String applyOnString(String t) {
         throw new IllegalArgumentException("Type not applicable for " + this.getClass().getSimpleName());
@@ -34,22 +42,27 @@ public abstract class Transformer {
     /**
      * Retrieves a transformer instance by its name.
      * Transformers can be acquired by their instance as well.
-     * @param identifier The string identifier of a transformer
+     * 
+     * @param identifier
+     *            The string identifier of a transformer
      * @return
      */
     public static Transformer toTransformer(String identifier) {
-        switch (identifier.toLowerCase()) {
-            case "capitalize":
-                return Capitalize.getInstance();
-            case "reverse":
-                return Reverse.getInstance();
-            case "nonnull":
-                return NonNull.getInstance();
-            case "negate":
-                return Negate.getInstance();
-            default:
-                throw new IllegalArgumentException(
-                        "The supplied string is not a valid transformer! Offender: {" + identifier + "}");
-        }
+        return switch (identifier.toLowerCase()) {
+            case "capitalize" -> Capitalize.getInstance();
+            case "reverse" -> Reverse.getInstance();
+            case "nonnull" -> NonNull.getInstance();
+            case "negate" -> Negate.getInstance();
+            default -> throw new IllegalArgumentException(
+                    "The supplied string is not a valid transformer! Offender: {" + identifier + "}");
+        };
+    }
+
+    public Function<Object, Object> toTypedFunction(AllowedTypes type) {
+        return switch (type) {
+            case INT -> (x) -> applyOnInteger((Integer) x);
+            case DOUBLE -> (x) -> applyOnDouble((Double) x);
+            default -> (x) -> applyOnString((String) x);
+        };
     }
 }

--- a/src/com/jonassigel/Transformers/Transformer.java
+++ b/src/com/jonassigel/Transformers/Transformer.java
@@ -2,7 +2,7 @@ package com.jonassigel.Transformers;
 
 import java.util.function.Function;
 
-import com.jonassigel.AllowedTypes;
+import com.jonassigel.AllowedType;
 
 /**
  * Declares data types that can be transformed.
@@ -11,6 +11,9 @@ import com.jonassigel.AllowedTypes;
  * 
  * If an operation wants to be capable for a type, it can override the specific
  * method. (Sadly type erasure destroyed another concept)
+ * 
+ * To add new types: Add an entry in AllowedType enum, add corresponding parent
+ * function and an entry for the typed function
  */
 public abstract class Transformer {
 
@@ -58,7 +61,7 @@ public abstract class Transformer {
         };
     }
 
-    public Function<Object, Object> toTypedFunction(AllowedTypes type) {
+    public Function<Object, Object> toTypedFunction(AllowedType type) {
         return switch (type) {
             case INT -> (x) -> applyOnInteger((Integer) x);
             case DOUBLE -> (x) -> applyOnDouble((Double) x);

--- a/src/com/jonassigel/Util.java
+++ b/src/com/jonassigel/Util.java
@@ -1,0 +1,19 @@
+package com.jonassigel;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Utility class for something Java should have itself: List-Composable
+ * functions. Multi-Type would be nice, but not very feasible tbh
+ */
+public class Util {
+    public static <T> Function<T, T> compose(List<Function<T, T>> funcs) {
+        return funcs.stream().reduce(Function.identity(), Function::andThen);
+    }
+
+    public static <T> Function<T, T> compose(Stream<Function<T, T>> funcs) {
+        return funcs.reduce(Function.identity(), Function::andThen);
+    }
+}

--- a/src/com/jonassigel/test/TransformTest.java
+++ b/src/com/jonassigel/test/TransformTest.java
@@ -4,9 +4,15 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
+import com.jonassigel.AllowedTypes;
 import com.jonassigel.Transform;
 import com.jonassigel.Transformers.Capitalize;
 import com.jonassigel.Transformers.Negate;
@@ -49,6 +55,13 @@ public class TransformTest {
     }
 
     @Test
+    public void testMultitypeTransform() {
+        List<Transformer> transformers = Transform.generateTransformersFrom("reverse");
+        assertEquals("tset", Transform.transform("test", transformers));
+        assertEquals(Integer.valueOf(1), Transform.transform(Integer.valueOf(1), transformers));
+    }
+
+    @Test
     public void testIllegalTransform() {
         List<Transformer> transformers = Transform.generateTransformersFrom("reverse", "negate");
         try {
@@ -57,6 +70,25 @@ public class TransformTest {
         } catch (Exception e) {
             assertTrue(e instanceof IllegalArgumentException);
         }
+    }
+
+    @Test
+    public void testTryWriteout() throws IOException {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        OutputStreamWriter output = new OutputStreamWriter(result);
+        Transform.tryConsume("Hello", output);
+        output.flush();
+        assertEquals("Hello\n", result.toString());
+    }
+
+    @Test
+    public void testStreamTransform() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        List<Transformer> transformers = Transform.generateTransformersFrom("reverse");
+        Stream<String> source = Arrays.asList("Hello", "World").stream();
+        Transform.transformInput(AllowedTypes.STRING, output, transformers, source);
+        assertEquals("olleH\ndlroW\n", output.toString());
+
     }
 
 }


### PR DESCRIPTION
Removed a lot of redundancy and made more effective use of functional references by changing some stuff and adding an enum of allowed types. 